### PR TITLE
chore: Handling navigation with and without menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@react-native-tvos/config-tv": "^0.0.4",
+    "@react-navigation/bottom-tabs": "^6.5.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-native-web": "^0.19.6"

--- a/packages/example/App.tsx
+++ b/packages/example/App.tsx
@@ -88,4 +88,5 @@ const Container = styled.View<{ width: number; height: number }>(({ width, heigh
   width,
   height,
   flexDirection: 'row-reverse',
+  backgroundColor: theme.colors.background.main,
 }));

--- a/packages/example/App.tsx
+++ b/packages/example/App.tsx
@@ -1,24 +1,52 @@
 import { ThemeProvider } from '@emotion/react';
 import { NavigationContainer } from '@react-navigation/native';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useWindowDimensions } from 'react-native';
 import { GoBackConfiguration } from './src/components/GoBackConfiguration';
 import { theme } from './src/design-system/theme/theme';
-import { ProgramInfo } from './src/modules/program/domain/programInfo';
 import { Home } from './src/pages/Home';
-import { ProgramDetail } from './src/pages/ProgramDetail';
 import { ProgramGridPage } from './src/pages/ProgramGridPage';
 import { Menu } from './src/components/Menu/Menu';
 import { MenuProvider } from './src/components/Menu/MenuContext';
 import styled from '@emotion/native';
 import { useFonts } from './src/hooks/useFonts';
+import { BottomTabBarProps, createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { ProgramInfo } from './src/modules/program/domain/programInfo';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { ProgramDetail } from './src/pages/ProgramDetail';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
-export type RootStackParamList = {
+const Tab = createBottomTabNavigator<RootTabParamList>();
+
+export type RootTabParamList = {
   Home: undefined;
-  ProgramDetail: { programInfo: ProgramInfo };
   ProgramGridPage: undefined;
+};
+
+export type RootStackParamList = {
+  TabNavigator: undefined;
+  ProgramDetail: { programInfo: ProgramInfo };
+};
+
+const RenderMenu = (props: BottomTabBarProps) => <Menu {...props} />;
+
+const TabNavigator = () => {
+  return (
+    <Tab.Navigator
+      screenOptions={{
+        headerShown: false,
+      }}
+      initialRouteName="Home"
+      tabBar={RenderMenu}
+      sceneContainerStyle={{
+        marginLeft: theme.sizes.menu.closed,
+        backgroundColor: theme.colors.background.main,
+      }}
+    >
+      <Tab.Screen name="Home" component={Home} />
+      <Tab.Screen name="ProgramGridPage" component={ProgramGridPage} />
+    </Tab.Navigator>
+  );
 };
 
 function App(): JSX.Element {
@@ -42,13 +70,11 @@ function App(): JSX.Element {
                   backgroundColor: theme.colors.background.main,
                 },
               }}
-              initialRouteName="Home"
+              initialRouteName="TabNavigator"
             >
-              <Stack.Screen name="Home" component={Home} />
+              <Stack.Screen name="TabNavigator" component={TabNavigator} />
               <Stack.Screen name="ProgramDetail" component={ProgramDetail} />
-              <Stack.Screen name="ProgramGridPage" component={ProgramGridPage} />
             </Stack.Navigator>
-            <Menu />
           </Container>
         </MenuProvider>
       </ThemeProvider>

--- a/packages/example/src/components/Menu/MenuButton.tsx
+++ b/packages/example/src/components/Menu/MenuButton.tsx
@@ -1,0 +1,64 @@
+import styled from '@emotion/native';
+import { forwardRef } from 'react';
+import { Animated, View } from 'react-native';
+import {
+  SpatialNavigationNode,
+  useSpatialNavigatorFocusableAccessibilityProps,
+} from 'react-tv-space-navigation';
+import { Typography } from '../../design-system/components/Typography';
+import { scaledPixels } from '../../design-system/helpers/scaledPixels';
+import { useFocusAnimation } from '../../design-system/helpers/useFocusAnimation';
+
+type ButtonProps = {
+  label: string;
+  isMenuOpen: boolean;
+  onSelect?: () => void;
+};
+
+const ButtonContent = forwardRef<View, { label: string; isFocused: boolean; isMenuOpen: boolean }>(
+  (props, ref) => {
+    const { isFocused, label, isMenuOpen } = props;
+    const anim = useFocusAnimation(isFocused && isMenuOpen);
+    const accessibilityProps = useSpatialNavigatorFocusableAccessibilityProps();
+    return (
+      <Container
+        style={anim}
+        isFocused={isFocused}
+        isMenuOpen={isMenuOpen}
+        ref={ref}
+        {...accessibilityProps}
+      >
+        <ColoredTypography isFocused={isFocused} isMenuOpen={isMenuOpen}>
+          {label}
+        </ColoredTypography>
+      </Container>
+    );
+  },
+);
+
+ButtonContent.displayName = 'ButtonContent';
+
+export const MenuButton = ({ label, isMenuOpen, onSelect }: ButtonProps) => {
+  return (
+    <SpatialNavigationNode isFocusable onSelect={onSelect}>
+      {({ isFocused }) => (
+        <ButtonContent label={label} isFocused={isFocused} isMenuOpen={isMenuOpen} />
+      )}
+    </SpatialNavigationNode>
+  );
+};
+
+const Container = styled(Animated.View)<{ isFocused: boolean; isMenuOpen: boolean }>(
+  ({ isFocused, isMenuOpen, theme }) => ({
+    alignSelf: 'baseline',
+    backgroundColor: isFocused && isMenuOpen ? 'white' : 'black',
+    padding: theme.spacings.$4,
+    borderRadius: scaledPixels(12),
+  }),
+);
+
+const ColoredTypography = styled(Typography)<{ isFocused: boolean; isMenuOpen: boolean }>(
+  ({ isFocused, isMenuOpen }) => ({
+    color: isFocused && isMenuOpen ? 'black' : 'white',
+  }),
+);

--- a/packages/example/src/components/VirtualizedSpatialGrid.tsx
+++ b/packages/example/src/components/VirtualizedSpatialGrid.tsx
@@ -8,7 +8,7 @@ import { scaledPixels } from '../design-system/helpers/scaledPixels';
 
 const NUMBER_OF_ROWS_VISIBLE_ON_SCREEN = 2;
 const NUMBER_OF_RENDERED_ROWS = NUMBER_OF_ROWS_VISIBLE_ON_SCREEN + 3;
-const NUMBER_OF_COLUMNS = 6;
+const NUMBER_OF_COLUMNS = 7;
 const INFINITE_SCROLL_ROW_THRESHOLD = 2;
 
 export const VirtualizedSpatialGrid = ({
@@ -42,9 +42,10 @@ export const VirtualizedSpatialGrid = ({
 
 const styles = StyleSheet.create({
   container: {
-    height: scaledPixels(780),
+    height: scaledPixels(1000),
     backgroundColor: '#222',
     padding: scaledPixels(30),
+    paddingLeft: scaledPixels(75),
     borderRadius: scaledPixels(20),
     overflow: 'hidden',
   },

--- a/packages/example/src/design-system/theme/sizes.ts
+++ b/packages/example/src/design-system/theme/sizes.ts
@@ -6,7 +6,7 @@ export const sizes = {
     portrait: { width: scaledPixels(200), height: scaledPixels(250) },
   },
   menu: {
-    open: scaledPixels(200),
-    closed: scaledPixels(80),
+    open: scaledPixels(400),
+    closed: scaledPixels(100),
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4692,6 +4692,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-navigation/bottom-tabs@npm:^6.5.11":
+  version: 6.5.11
+  resolution: "@react-navigation/bottom-tabs@npm:6.5.11"
+  dependencies:
+    "@react-navigation/elements": ^1.3.21
+    color: ^4.2.3
+    warn-once: ^0.1.0
+  peerDependencies:
+    "@react-navigation/native": ^6.0.0
+    react: "*"
+    react-native: "*"
+    react-native-safe-area-context: ">= 3.0.0"
+    react-native-screens: ">= 3.0.0"
+  checksum: 40719f03d926ddf046f395e1e3007b8e3b64b82ecdf33a397b7b2eb9b0387fdd00ece2089db670e6d339838bd0658ee279b9409873bbeb28df89ad86f8f09140
+  languageName: node
+  linkType: hard
+
 "@react-navigation/core@npm:^6.4.10":
   version: 6.4.10
   resolution: "@react-navigation/core@npm:6.4.10"
@@ -7262,10 +7279,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-name@npm:~1.1.4":
+"color-name@npm:^1.0.0, color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: b0445859521eb4021cd0fb0cc1a75cecf67fceecae89b63f62b201cca8d345baf8b952c966862a9d9a2632987d4f6581f0ec8d957dfacece86f0a7919316f610
+  languageName: node
+  linkType: hard
+
+"color-string@npm:^1.9.0":
+  version: 1.9.1
+  resolution: "color-string@npm:1.9.1"
+  dependencies:
+    color-name: ^1.0.0
+    simple-swizzle: ^0.2.2
+  checksum: c13fe7cff7885f603f49105827d621ce87f4571d78ba28ef4a3f1a104304748f620615e6bf065ecd2145d0d9dad83a3553f52bb25ede7239d18e9f81622f1cc5
   languageName: node
   linkType: hard
 
@@ -7275,6 +7302,16 @@ __metadata:
   bin:
     color-support: bin.js
   checksum: 9b7356817670b9a13a26ca5af1c21615463b500783b739b7634a0c2047c16cef4b2865d7576875c31c3cddf9dd621fa19285e628f20198b233a5cfdda6d0793b
+  languageName: node
+  linkType: hard
+
+"color@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "color@npm:4.2.3"
+  dependencies:
+    color-convert: ^2.0.1
+    color-string: ^1.9.0
+  checksum: 0579629c02c631b426780038da929cca8e8d80a40158b09811a0112a107c62e10e4aad719843b791b1e658ab4e800558f2e87ca4522c8b32349d497ecb6adeb4
   languageName: node
   linkType: hard
 
@@ -10564,6 +10601,13 @@ __metadata:
   version: 0.2.1
   resolution: "is-arrayish@npm:0.2.1"
   checksum: eef4417e3c10e60e2c810b6084942b3ead455af16c4509959a27e490e7aee87cfb3f38e01bbde92220b528a0ee1a18d52b787e1458ee86174d8c7f0e58cd488f
+  languageName: node
+  linkType: hard
+
+"is-arrayish@npm:^0.3.1":
+  version: 0.3.2
+  resolution: "is-arrayish@npm:0.3.2"
+  checksum: 977e64f54d91c8f169b59afcd80ff19227e9f5c791fa28fa2e5bce355cbaf6c2c356711b734656e80c9dd4a854dd7efcf7894402f1031dfc5de5d620775b4d5f
   languageName: node
   linkType: hard
 
@@ -14480,6 +14524,7 @@ __metadata:
     "@babel/preset-typescript": ^7.22.5
     "@react-native-community/eslint-config": ^3.2.0
     "@react-native-tvos/config-tv": ^0.0.4
+    "@react-navigation/bottom-tabs": ^6.5.11
     "@types/react": ^18.2.14
     "@types/react-dom": ^18.2.6
     "@typescript-eslint/eslint-plugin": ^5.60.1
@@ -15379,6 +15424,15 @@ __metadata:
     bplist-parser: 0.3.2
     plist: ^3.0.5
   checksum: fa8086f6b781c289f1abad21306481dda4af6373b32a5d998a70e53c2b7218a1d21ebb5ae3e736baae704c21d311d3d39d01d0e6a2387eda01b4020b9ebd909e
+  languageName: node
+  linkType: hard
+
+"simple-swizzle@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "simple-swizzle@npm:0.2.2"
+  dependencies:
+    is-arrayish: ^0.3.1
+  checksum: a7f3f2ab5c76c4472d5c578df892e857323e452d9f392e1b5cf74b74db66e6294a1e1b8b390b519fa1b96b5b613f2a37db6cffef52c3f1f8f3c5ea64eb2d54c0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR aims to add the support of two routers, one that handles the menu, and one without. 
It allows a screen management which differentiates screens that need the side menu from screens that don't.

The tab navigator is used for navigation between menu screens.

This PR contains : 
- refactor of the routers by separating screen with and without menu
- refactoring menu to use it as tabBar in TabNavigator
- adding an active page indicator
- layout adjustment

| Menu opened | Menu closed |
|--------|--------|
| ![image](https://github.com/bamlab/react-tv-space-navigation/assets/103206306/9363b87e-5335-4fc3-bddf-9c17c3a8cc5e) | ![image](https://github.com/bamlab/react-tv-space-navigation/assets/103206306/6a2ef7a0-42c0-416a-ab57-426c60033ce6) |
| ![image](https://github.com/bamlab/react-tv-space-navigation/assets/103206306/2c072096-ed25-49a1-8a22-11f8140a6625) | ![image](https://github.com/bamlab/react-tv-space-navigation/assets/103206306/45dda450-c03c-43f8-9cf6-9e7e9dc59f2e) | 







