### PR TITLE
chore: add display name to typedMemos

### DIFF
--- a/packages/lib/src/spatial-navigation/components/virtualizedGrid/SpatialNavigationVirtualizedGrid.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedGrid/SpatialNavigationVirtualizedGrid.tsx
@@ -92,6 +92,7 @@ const ItemWrapperWithVirtualParentContext = typedMemo(
     </ParentIdContext.Provider>
   ),
 );
+ItemWrapperWithVirtualParentContext.displayName = 'ItemWrapperWithVirtualParentContext';
 
 const GridRow = <T extends ItemWithIndex>({
   renderItem,
@@ -216,6 +217,7 @@ export const SpatialNavigationVirtualizedGrid = typedMemo(
     );
   },
 );
+SpatialNavigationVirtualizedGrid.displayName = 'SpatialNavigationVirtualizedGrid';
 
 type HorizontalContainerProps = {
   style?: ViewStyle;

--- a/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedList.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedList.tsx
@@ -29,3 +29,4 @@ export const SpatialNavigationVirtualizedList = typedMemo(
     );
   },
 );
+SpatialNavigationVirtualizedList.displayName = 'SpatialNavigationVirtualizedList';

--- a/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedListWithScroll.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedListWithScroll.tsx
@@ -40,6 +40,7 @@ const ItemWrapperWithScrollContext = typedMemo(
     );
   },
 );
+ItemWrapperWithScrollContext.displayName = 'ItemWrapperWithScrollContext';
 
 export type SpatialNavigationVirtualizedListWithScrollProps<T> = Omit<
   SpatialNavigationVirtualizedListWithVirtualNodesProps<T>,
@@ -78,3 +79,5 @@ export const SpatialNavigationVirtualizedListWithScroll = typedMemo(
     );
   },
 );
+SpatialNavigationVirtualizedListWithScroll.displayName =
+  'SpatialNavigationVirtualizedListWithScroll';

--- a/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedListWithVirtualNodes.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedListWithVirtualNodes.tsx
@@ -128,6 +128,7 @@ const ItemWrapperWithVirtualParentContext = typedMemo(
     </ParentIdContext.Provider>
   ),
 );
+ItemWrapperWithVirtualParentContext.displayName = 'ItemWrapperWithVirtualParentContext';
 
 export type SpatialNavigationVirtualizedListWithVirtualNodesProps<T> = Omit<
   VirtualizedListProps<T>,
@@ -183,3 +184,5 @@ export const SpatialNavigationVirtualizedListWithVirtualNodes = typedMemo(
     return <VirtualizedListWithSize {...props} renderItem={renderWrappedItem} />;
   },
 );
+SpatialNavigationVirtualizedListWithVirtualNodes.displayName =
+  'SpatialNavigationVirtualizedListWithVirtualNodes';

--- a/packages/lib/src/spatial-navigation/components/virtualizedList/VirtualizedList.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/VirtualizedList.tsx
@@ -121,6 +121,7 @@ const ItemContainerWithAnimatedStyle = typedMemo(
     return <View style={style}>{renderItem({ item })}</View>;
   },
 );
+ItemContainerWithAnimatedStyle.displayName = 'ItemContainerWithAnimatedStyle';
 
 /**
  * DO NOT use this component directly !
@@ -286,6 +287,7 @@ export const VirtualizedList = typedMemo(
     );
   },
 );
+VirtualizedList.displayName = 'VirtualizedList';
 
 const styles = StyleSheet.create({
   container: {

--- a/packages/lib/src/spatial-navigation/components/virtualizedList/VirtualizedListWithSize.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/VirtualizedListWithSize.tsx
@@ -34,6 +34,7 @@ export const VirtualizedListWithSize = typedMemo(
     );
   },
 );
+VirtualizedListWithSize.displayName = 'VirtualizedListWithSize';
 
 const style = StyleSheet.create({
   container: {


### PR DESCRIPTION
Adding missing displayName to memo in order to make debugging easier

| Before | After |
|--------|--------|
| <img width="642" alt="image" src="https://github.com/bamlab/react-tv-space-navigation/assets/103206306/1bf03b21-735b-41cf-a3b1-5bcd2fc94a7f"> | <img width="644" alt="image" src="https://github.com/bamlab/react-tv-space-navigation/assets/103206306/21a82dc9-72fa-44ea-b1eb-3ebc030a557c"> |