### PR TITLE
refactor: set list size from the wrapper and only in the right list axis

### DIFF
--- a/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedListWithVirtualNodes.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedListWithVirtualNodes.tsx
@@ -132,7 +132,7 @@ ItemWrapperWithVirtualParentContext.displayName = 'ItemWrapperWithVirtualParentC
 
 export type SpatialNavigationVirtualizedListWithVirtualNodesProps<T> = Omit<
   VirtualizedListProps<T>,
-  'width' | 'height'
+  'listSizeInPx'
 > & {
   isGrid?: boolean;
 };

--- a/packages/lib/src/spatial-navigation/components/virtualizedList/VirtualizedList.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/VirtualizedList.tsx
@@ -45,10 +45,8 @@ export interface VirtualizedListProps<T> {
   nbMaxOfItems?: number;
   /** Duration of a scrolling animation inside the VirtualizedList */
   scrollDuration?: number;
-  /** Custom height for the VirtualizedList container */
-  height: number;
-  /** Custom width for the VirtualizedList container */
-  width: number;
+  /** The size of the list in its scrollable axis */
+  listSizeInPx: number;
   scrollBehavior?: ScrollBehavior;
   testID?: string;
 }
@@ -146,9 +144,8 @@ export const VirtualizedList = typedMemo(
     nbMaxOfItems,
     keyExtractor,
     scrollDuration = 200,
+    listSizeInPx,
     scrollBehavior = 'stick-to-start',
-    height,
-    width,
     testID,
   }: VirtualizedListProps<T>) => {
     const range = getRange({
@@ -159,8 +156,6 @@ export const VirtualizedList = typedMemo(
     });
 
     const vertical = orientation === 'vertical';
-
-    const listSizeInPx = vertical ? height : width;
 
     const totalVirtualizedListSize = useMemo(
       () => getSizeInPxFromOneItemToAnother(data, itemSize, 0, data.length),

--- a/packages/lib/src/spatial-navigation/components/virtualizedList/VirtualizedListWithSize.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/VirtualizedListWithSize.tsx
@@ -11,25 +11,22 @@ import { useState } from 'react';
  * doesn't support dynamic size changes.
  */
 export const VirtualizedListWithSize = typedMemo(
-  <T extends ItemWithIndex>(props: Omit<VirtualizedListProps<T>, 'width' | 'height'>) => {
-    const [viewHeight, setViewHeight] = useState<number | null>(null);
-    const [viewWidth, setViewWidth] = useState<number | null>(null);
-    const shouldRender = viewWidth && viewHeight;
+  <T extends ItemWithIndex>(props: Omit<VirtualizedListProps<T>, 'listSizeInPx'>) => {
+    const [listSizeInPx, setListSizeInPx] = useState<number | null>(null);
+    const isVertical = props.orientation === 'vertical';
 
     return (
       <View
         style={style.container}
         onLayout={(event) => {
-          if (!viewHeight) {
-            setViewHeight(event.nativeEvent.layout.height);
-          }
-          if (!viewWidth) {
-            setViewWidth(event.nativeEvent.layout.width);
+          if (!listSizeInPx) {
+            const sizeKey = isVertical ? 'height' : 'width';
+            setListSizeInPx(event.nativeEvent.layout[sizeKey]);
           }
         }}
         testID={props.testID ? props.testID + '-size-giver' : undefined}
       >
-        {shouldRender ? <VirtualizedList {...props} width={viewWidth} height={viewHeight} /> : null}
+        {listSizeInPx ? <VirtualizedList {...props} listSizeInPx={listSizeInPx} /> : null}
       </View>
     );
   },


### PR DESCRIPTION
Fix to compute the size of the list only in the relevant axis and not using the other axis