### PR TITLE
chore(example): add pointer style when hovering clickable

### DIFF
--- a/packages/example/src/components/Menu/MenuButton.tsx
+++ b/packages/example/src/components/Menu/MenuButton.tsx
@@ -62,5 +62,6 @@ const Container = styled(Animated.View)<{ isFocused: boolean; isMenuOpen: boolea
     backgroundColor: isFocused && isMenuOpen ? 'white' : 'black',
     padding: theme.spacings.$4,
     borderRadius: scaledPixels(12),
+    cursor: 'pointer',
   }),
 );

--- a/packages/example/src/design-system/components/Button.tsx
+++ b/packages/example/src/design-system/components/Button.tsx
@@ -40,6 +40,7 @@ const Container = styled(Animated.View)<{ isFocused: boolean }>(({ isFocused, th
   backgroundColor: isFocused ? 'white' : 'black',
   padding: theme.spacings.$4,
   borderRadius: scaledPixels(12),
+  cursor: 'pointer',
 }));
 
 const ColoredTypography = styled(Typography)<{ isFocused: boolean }>(({ isFocused }) => ({

--- a/packages/example/src/modules/program/view/Program.tsx
+++ b/packages/example/src/modules/program/view/Program.tsx
@@ -40,6 +40,7 @@ const ProgramContainer = styled(Animated.View)<{ isFocused: boolean }>(({ isFocu
   borderRadius: 20,
   borderColor: isFocused ? theme.colors.primary.light : 'transparent',
   borderWidth: 3,
+  cursor: 'pointer',
 }));
 
 const ProgramImage = styled(Image)({


### PR DESCRIPTION
Add pointer style for clickable elements


![Feb-27-2024 18-09-12](https://github.com/bamlab/react-tv-space-navigation/assets/103206306/5dfc3338-dfe9-40d1-b091-28c880ee79a4)
