### PR TITLE
fix: prevent setting virtualized list size to zero

### DIFF
--- a/packages/lib/src/spatial-navigation/components/virtualizedList/VirtualizedListWithSize.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/VirtualizedListWithSize.tsx
@@ -24,8 +24,10 @@ export const VirtualizedListWithSize = typedMemo(
         onLayout={(event) => {
           if (!hasAlreadyRendered) {
             const sizeKey = isVertical ? 'height' : 'width';
-            setListSizeInPx(event.nativeEvent.layout[sizeKey]);
-            setHasAlreadyRendered(true);
+            if (event.nativeEvent.layout[sizeKey] !== 0) {
+              setListSizeInPx(event.nativeEvent.layout[sizeKey]);
+              setHasAlreadyRendered(true);
+            }
           }
         }}
         testID={props.testID ? props.testID + '-size-giver' : undefined}


### PR DESCRIPTION
Can happen when using a tab navigator for example, page is still mounted so onlayout will be triggered, but size will be set to 0