### PR TITLE
Calculate scaled factors for pixel with react-native-pixel-perfect

### DIFF
--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -29,6 +29,7 @@
     "react": "18.2.0",
     "react-native": "npm:react-native-tvos@0.73.2-0",
     "react-native-keyevent": "^0.3.2",
+    "react-native-pixel-perfect": "^1.0.2",
     "react-native-safe-area-context": "^4.8.2",
     "react-native-screens": "^3.29.0",
     "react-native-svg": "^14.1.0",

--- a/packages/example/src/design-system/helpers/scaledPixels.ts
+++ b/packages/example/src/design-system/helpers/scaledPixels.ts
@@ -1,13 +1,8 @@
-import { Dimensions } from 'react-native';
+import { create } from 'react-native-pixel-perfect';
 
-export const screen = Dimensions.get('window');
-const scale = (screen.width || 1920) / 1920;
+const designResolution = {
+  width: 1920,
+  height: 1080,
+};
 
-/**
- * Unfortunately, AndroidTV handles pixels in a strange manner
- * PixelRatio does not seem to solve the problem properly on web.
- * So we just scale the pixels manually.
- *
- * https://github.com/react-native-tvos/react-native-tvos/issues/57
- */
-export const scaledPixels = (pixels: number) => pixels * scale;
+export const scaledPixels = create(designResolution);


### PR DESCRIPTION
I've found the using [react-native-pixel-perfect](https://www.npmjs.com/package/react-native-pixel-perfect) makes it easier to adapt the scaling factor across different screens.

The library is considering width and height that can be defined by the developers or runtime.

Tested on Android TV, Fire TV, tvOS and web. 

Check if it makes sense! Thank you!