### PR TITLE
Detect back button event from LG Magic remote

### DIFF
--- a/packages/example/src/components/remote-control/RemoteControlManager.ts
+++ b/packages/example/src/components/remote-control/RemoteControlManager.ts
@@ -19,11 +19,15 @@ class RemoteControlManager implements RemoteControlManagerInterface {
       Backspace: SupportedKeys.Back,
     }[event.code];
 
-    if (!mappedKey) {
-      return;
+    //For LG WebOs Magic Remote
+    if (event.key === 'GoBack') {
+      this.eventEmitter.emit('keyDown', SupportedKeys.Back);
+    } else {
+      if (!mappedKey) {
+        return;
+      }
+      this.eventEmitter.emit('keyDown', mappedKey);
     }
-
-    this.eventEmitter.emit('keyDown', mappedKey);
   };
 
   addKeydownListener = (listener: (event: SupportedKeys) => void) => {


### PR DESCRIPTION
This to detect the "Back" button of an LG Magic Remote for Web OS.
Tested with the web build of the project.

The appinfo.json of the WebOS project needs to include

`  "disableBackHistoryAPI": true`

More info for LG WebOS [here](https://webostv.developer.lge.com/develop/guides/back-button)
