### PR TITLE
Refactor(ItemWithIndex): remove ItemWithIndex type

### DIFF
--- a/packages/lib/src/spatial-navigation/components/virtualizedGrid/SpatialNavigationVirtualizedGrid.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedGrid/SpatialNavigationVirtualizedGrid.tsx
@@ -241,9 +241,11 @@ export const SpatialNavigationVirtualizedGrid = typedMemo(
         if (React.isValidElement(item)) {
           return item;
         }
-        return renderRow({ item: item as GridRowType<T>, index });
+        //We do this to have index taking into account the header
+        const computedIndex = hasHeader ? index - 1 : index;
+        return renderRow({ item: item as GridRowType<T>, index: computedIndex });
       },
-      [renderRow],
+      [hasHeader, renderRow],
     );
 
     return (

--- a/packages/lib/src/spatial-navigation/components/virtualizedGrid/SpatialNavigationVirtualizedGrid.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedGrid/SpatialNavigationVirtualizedGrid.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode, useCallback, useEffect, useMemo } from 'react';
 import { View, ViewStyle, StyleSheet } from 'react-native';
 import range from 'lodash/range';
 
-import { ItemWithIndex } from '../virtualizedList/VirtualizedList';
 import { SpatialNavigationVirtualizedList } from '../virtualizedList/SpatialNavigationVirtualizedList';
 import {
   PointerScrollProps,
@@ -13,7 +12,7 @@ import { ParentIdContext, useParentId } from '../../context/ParentIdContext';
 import { typedMemo } from '../../helpers/TypedMemo';
 import { convertToGrid } from './helpers/convertToGrid';
 
-type SpatialNavigationVirtualizedGridProps<T extends ItemWithIndex> = Pick<
+type SpatialNavigationVirtualizedGridProps<T> = Pick<
   SpatialNavigationVirtualizedListWithScrollProps<T>,
   | 'data'
   | 'renderItem'
@@ -40,9 +39,8 @@ type SpatialNavigationVirtualizedGridProps<T extends ItemWithIndex> = Pick<
     rowContainerStyle?: ViewStyle;
   };
 
-export type GridRowType<T extends ItemWithIndex> = {
+export type GridRowType<T> = {
   items: T[];
-  index: number;
 };
 
 const useRegisterGridRowVirtualNodes = ({ numberOfColumns }: { numberOfColumns: number }) => {
@@ -84,7 +82,7 @@ const useRegisterGridRowVirtualNodes = ({ numberOfColumns }: { numberOfColumns: 
 };
 
 const ItemWrapperWithVirtualParentContext = typedMemo(
-  <T extends ItemWithIndex>({
+  <T,>({
     virtualParentID,
     item,
     index,
@@ -102,7 +100,7 @@ const ItemWrapperWithVirtualParentContext = typedMemo(
 );
 ItemWrapperWithVirtualParentContext.displayName = 'ItemWrapperWithVirtualParentContext';
 
-const GridRow = <T extends ItemWithIndex>({
+const GridRow = <T,>({
   renderItem,
   numberOfColumns,
   row,
@@ -187,7 +185,7 @@ const GridRow = <T extends ItemWithIndex>({
  */
 
 export const SpatialNavigationVirtualizedGrid = typedMemo(
-  <T extends ItemWithIndex>({
+  <T,>({
     renderItem,
     data,
     numberOfColumns,

--- a/packages/lib/src/spatial-navigation/components/virtualizedGrid/helpers/convertToGrid.ts
+++ b/packages/lib/src/spatial-navigation/components/virtualizedGrid/helpers/convertToGrid.ts
@@ -1,9 +1,9 @@
 import chunk from 'lodash/chunk';
 import { GridRowType } from '../SpatialNavigationVirtualizedGrid';
-import { ItemWithIndex } from '../../virtualizedList/VirtualizedList';
+
 import { NodeOrientation } from '../../../types/orientation';
 
-export const convertToGrid = <T extends ItemWithIndex>(
+export const convertToGrid = <T>(
   data: T[],
   numberOfColumns: number,
   header?: JSX.Element,

--- a/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedList.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedList.tsx
@@ -7,7 +7,6 @@ import {
 } from './SpatialNavigationVirtualizedListWithScroll';
 import { typedMemo } from '../../helpers/TypedMemo';
 import { addIndex } from './helpers/addIndex';
-import { ItemWithIndex } from './VirtualizedList';
 import { typedForwardRef } from '../../helpers/TypedForwardRef';
 import { SpatialNavigationVirtualizedListRef } from '../../types/SpatialNavigationVirtualizedListRef';
 
@@ -28,11 +27,7 @@ export const SpatialNavigationVirtualizedList = typedMemo(
           alignInGrid={props.isGrid ?? false}
           orientation={props.orientation ?? 'horizontal'}
         >
-          <SpatialNavigationVirtualizedListWithScroll<T & ItemWithIndex>
-            {...props}
-            data={indexedData}
-            ref={ref}
-          />
+          <SpatialNavigationVirtualizedListWithScroll<T> {...props} data={indexedData} ref={ref} />
         </SpatialNavigationNode>
       );
     },

--- a/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedList.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedList.tsx
@@ -1,4 +1,4 @@
-import { ForwardedRef, useMemo } from 'react';
+import { ForwardedRef } from 'react';
 import { SpatialNavigationNode } from '../Node';
 import {
   PointerScrollProps,
@@ -6,7 +6,7 @@ import {
   SpatialNavigationVirtualizedListWithScrollProps,
 } from './SpatialNavigationVirtualizedListWithScroll';
 import { typedMemo } from '../../helpers/TypedMemo';
-import { addIndex } from './helpers/addIndex';
+
 import { typedForwardRef } from '../../helpers/TypedForwardRef';
 import { SpatialNavigationVirtualizedListRef } from '../../types/SpatialNavigationVirtualizedListRef';
 
@@ -20,14 +20,12 @@ export const SpatialNavigationVirtualizedList = typedMemo(
       props: SpatialNavigationVirtualizedListWithScrollProps<T> & PointerScrollProps,
       ref: ForwardedRef<SpatialNavigationVirtualizedListRef>,
     ) => {
-      const indexedData = useMemo(() => addIndex(props.data), [props.data]);
-
       return (
         <SpatialNavigationNode
           alignInGrid={props.isGrid ?? false}
           orientation={props.orientation ?? 'horizontal'}
         >
-          <SpatialNavigationVirtualizedListWithScroll<T> {...props} data={indexedData} ref={ref} />
+          <SpatialNavigationVirtualizedListWithScroll<T> {...props} ref={ref} />
         </SpatialNavigationNode>
       );
     },

--- a/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedListWithScroll.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedListWithScroll.tsx
@@ -23,10 +23,12 @@ const ItemWrapperWithScrollContext = typedMemo(
   <T extends ItemWithIndex>({
     setCurrentlyFocusedItemIndex,
     item,
+    index,
     renderItem,
   }: {
     setCurrentlyFocusedItemIndex: (i: number) => void;
     item: T;
+    index: number;
     renderItem: VirtualizedListProps<T>['renderItem'];
   }) => {
     const { scrollToNodeIfNeeded: makeParentsScrollToNodeIfNeeded } =
@@ -34,16 +36,16 @@ const ItemWrapperWithScrollContext = typedMemo(
 
     const scrollToItem: ScrollToNodeCallback = useCallback(
       (newlyFocusedElementRef, additionalOffset) => {
-        setCurrentlyFocusedItemIndex(item.index);
+        setCurrentlyFocusedItemIndex(index);
         // We need to propagate the scroll event for parents if we have nested ScrollViews/VirtualizedLists.
         makeParentsScrollToNodeIfNeeded(newlyFocusedElementRef, additionalOffset);
       },
-      [makeParentsScrollToNodeIfNeeded, setCurrentlyFocusedItemIndex, item.index],
+      [makeParentsScrollToNodeIfNeeded, setCurrentlyFocusedItemIndex, index],
     );
 
     return (
       <SpatialNavigatorParentScrollContext.Provider value={scrollToItem}>
-        {renderItem({ item, index: item.index })}
+        {renderItem({ item, index })}
       </SpatialNavigatorParentScrollContext.Provider>
     );
   },
@@ -210,11 +212,12 @@ export const SpatialNavigationVirtualizedListWithScroll = typedMemo(
       );
 
       const renderWrappedItem: typeof props.renderItem = useCallback(
-        ({ item }) => (
+        ({ item, index }) => (
           <ItemWrapperWithScrollContext
             setCurrentlyFocusedItemIndex={setCurrentlyFocusedItemIndexCallback}
             renderItem={renderItem}
             item={item}
+            index={index}
           />
         ),
         [setCurrentlyFocusedItemIndexCallback, renderItem],

--- a/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedListWithScroll.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedListWithScroll.tsx
@@ -1,5 +1,5 @@
 import { ForwardedRef, useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react';
-import { VirtualizedListProps, ItemWithIndex } from './VirtualizedList';
+import { VirtualizedListProps } from './VirtualizedList';
 
 import {
   SpatialNavigationVirtualizedListWithVirtualNodes,
@@ -20,7 +20,7 @@ import { typedForwardRef } from '../../helpers/TypedForwardRef';
 import { SpatialNavigationVirtualizedListRef } from '../../types/SpatialNavigationVirtualizedListRef';
 
 const ItemWrapperWithScrollContext = typedMemo(
-  <T extends ItemWithIndex>({
+  <T,>({
     setCurrentlyFocusedItemIndex,
     item,
     index,
@@ -65,14 +65,14 @@ export type PointerScrollProps = {
   scrollInterval?: number;
 };
 
-const useRemotePointerVirtualizedListScrollProps = ({
+const useRemotePointerVirtualizedListScrollProps = <T,>({
   setCurrentlyFocusedItemIndex,
   scrollInterval,
   data,
 }: {
   setCurrentlyFocusedItemIndex: React.Dispatch<React.SetStateAction<number>>;
   scrollInterval: number;
-  data: ItemWithIndex[];
+  data: T[];
 }) => {
   const {
     deviceType,
@@ -168,7 +168,7 @@ const useRemotePointerVirtualizedListScrollProps = ({
  */
 export const SpatialNavigationVirtualizedListWithScroll = typedMemo(
   typedForwardRef(
-    <T extends ItemWithIndex>(
+    <T,>(
       props: SpatialNavigationVirtualizedListWithScrollProps<T> & PointerScrollProps,
       ref: ForwardedRef<SpatialNavigationVirtualizedListRef>,
     ) => {

--- a/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedListWithVirtualNodes.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedListWithVirtualNodes.tsx
@@ -120,15 +120,17 @@ const useRegisterVirtualNodes = <T extends ItemWithIndex>({
 const ItemWrapperWithVirtualParentContext = typedMemo(
   <T extends ItemWithIndex>({
     virtualParentID,
+    index,
     item,
     renderItem,
   }: {
     virtualParentID: string;
     item: T;
+    index: number;
     renderItem: VirtualizedListProps<T>['renderItem'];
   }) => (
     <ParentIdContext.Provider value={virtualParentID}>
-      {renderItem({ item, index: item.index })}
+      {renderItem({ item, index: index })}
     </ParentIdContext.Provider>
   ),
 );
@@ -191,11 +193,12 @@ export const SpatialNavigationVirtualizedListWithVirtualNodes = typedMemo(
 
     const { renderItem } = props;
     const renderWrappedItem: typeof props.renderItem = useCallback(
-      ({ item }) => (
+      ({ item, index }) => (
         <ItemWrapperWithVirtualParentContext
-          virtualParentID={getNthVirtualNodeID(item.index)}
+          virtualParentID={getNthVirtualNodeID(index)}
           renderItem={renderItem}
           item={item}
+          index={index}
         />
       ),
       [getNthVirtualNodeID, renderItem],

--- a/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedListWithVirtualNodes.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedListWithVirtualNodes.tsx
@@ -1,6 +1,6 @@
 import uniqueId from 'lodash.uniqueid';
 import { useCallback, useEffect, useImperativeHandle, useRef } from 'react';
-import { VirtualizedListProps, ItemWithIndex } from './VirtualizedList';
+import { VirtualizedListProps } from './VirtualizedList';
 import { useSpatialNavigator } from '../../context/SpatialNavigatorContext';
 import { ParentIdContext, useParentId } from '../../context/ParentIdContext';
 import { updateVirtualNodeRegistration } from './helpers/updateVirtualNodeRegistration';
@@ -73,7 +73,7 @@ const useUpdateRegistration = <T,>({
   }, [allItems]);
 };
 
-const useRegisterVirtualNodes = <T extends ItemWithIndex>({
+const useRegisterVirtualNodes = <T,>({
   allItems,
   orientation,
   isGrid,
@@ -118,7 +118,7 @@ const useRegisterVirtualNodes = <T extends ItemWithIndex>({
 };
 
 const ItemWrapperWithVirtualParentContext = typedMemo(
-  <T extends ItemWithIndex>({
+  <T,>({
     virtualParentID,
     index,
     item,
@@ -172,7 +172,7 @@ export type SpatialNavigationVirtualizedListWithVirtualNodesRef = {
  * Framed letters correspond to rendered components.
  */
 export const SpatialNavigationVirtualizedListWithVirtualNodes = typedMemo(
-  <T extends ItemWithIndex>(
+  <T,>(
     props: SpatialNavigationVirtualizedListWithVirtualNodesProps<T> & {
       getNodeIdRef: React.Ref<SpatialNavigationVirtualizedListWithVirtualNodesRef>;
     },

--- a/packages/lib/src/spatial-navigation/components/virtualizedList/VirtualizedList.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/VirtualizedList.tsx
@@ -85,7 +85,7 @@ const useOnEndReached = ({
 };
 
 const ItemContainerWithAnimatedStyle = typedMemo(
-  <T extends ItemWithIndex>({
+  <T,>({
     item,
     index,
     renderItem,
@@ -132,7 +132,7 @@ ItemContainerWithAnimatedStyle.displayName = 'ItemContainerWithAnimatedStyle';
  *   - it is way more performant than a FlatList
  */
 export const VirtualizedList = typedMemo(
-  <T extends ItemWithIndex>({
+  <T,>({
     data,
     renderItem,
     itemSize,

--- a/packages/lib/src/spatial-navigation/components/virtualizedList/VirtualizedList.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/VirtualizedList.tsx
@@ -11,15 +11,6 @@ import { getLastLeftItemIndex, getLastRightItemIndex } from './helpers/getLastIt
 import { getSizeInPxFromOneItemToAnother } from './helpers/getSizeInPxFromOneItemToAnother';
 import { computeAllScrollOffsets } from './helpers/createScrollOffsetArray';
 
-/**
- * @TODO: VirtualizedList should be able to take any data as params.
- * We shouldn't restrict the use to a data that is indexed -> a mistake can be made on usage
- * if the data is not indexed properly for example.
- * The indexing should be done inside VirtualizedList directly & VirtualizedListProps
- * should accept any generic type T.
- */
-export type ItemWithIndex = { index: number };
-
 export type ScrollBehavior = 'stick-to-start' | 'stick-to-end' | 'jump-on-scroll';
 export interface VirtualizedListProps<T> {
   data: T[];

--- a/packages/lib/src/spatial-navigation/components/virtualizedList/VirtualizedList.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/VirtualizedList.tsx
@@ -87,22 +87,24 @@ const useOnEndReached = ({
 const ItemContainerWithAnimatedStyle = typedMemo(
   <T extends ItemWithIndex>({
     item,
+    index,
     renderItem,
     itemSize,
     vertical,
     data,
   }: {
     item: T;
+    index: number;
     renderItem: VirtualizedListProps<T>['renderItem'];
     itemSize: number | ((item: T) => number);
     vertical: boolean;
     data: T[];
   }) => {
     const computeOffset = useCallback(
-      (item: T) =>
+      (item: T, index: number) =>
         typeof itemSize === 'number'
-          ? item.index * itemSize
-          : data.slice(0, item.index).reduce((acc, item) => acc + itemSize(item), 0),
+          ? index * itemSize
+          : data.slice(0, index).reduce((acc, item) => acc + itemSize(item), 0),
       [data, itemSize],
     );
 
@@ -111,12 +113,12 @@ const ItemContainerWithAnimatedStyle = typedMemo(
         StyleSheet.flatten([
           styles.item,
           vertical
-            ? { transform: [{ translateY: computeOffset(item) }] }
-            : { transform: [{ translateX: computeOffset(item) }] },
+            ? { transform: [{ translateY: computeOffset(item, index) }] }
+            : { transform: [{ translateX: computeOffset(item, index) }] },
         ]),
-      [computeOffset, item, vertical],
+      [computeOffset, item, index, vertical],
     );
-    return <View style={style}>{renderItem({ item, index: item.index })}</View>;
+    return <View style={style}>{renderItem({ item, index })}</View>;
   },
 );
 ItemContainerWithAnimatedStyle.displayName = 'ItemContainerWithAnimatedStyle';
@@ -265,12 +267,14 @@ export const VirtualizedList = typedMemo(
         testID={testID}
       >
         <View>
-          {dataSliceToRender.map((item) => {
+          {dataSliceToRender.map((item, virtualIndex) => {
+            const index = range.start + virtualIndex;
             return (
               <ItemContainerWithAnimatedStyle<T>
-                key={keyExtractor ? keyExtractor(item.index) : recycledKeyExtractor(item.index)}
+                key={keyExtractor ? keyExtractor(index) : recycledKeyExtractor(index)}
                 renderItem={renderItem}
                 item={item}
+                index={index}
                 itemSize={itemSize}
                 vertical={vertical}
                 data={data}

--- a/packages/lib/src/spatial-navigation/components/virtualizedList/VirtualizedListWithSize.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/VirtualizedListWithSize.tsx
@@ -1,6 +1,6 @@
 import { StyleSheet, View, Dimensions } from 'react-native';
 import { typedMemo } from '../../helpers/TypedMemo';
-import { ItemWithIndex, VirtualizedList, VirtualizedListProps } from './VirtualizedList';
+import { VirtualizedList, VirtualizedListProps } from './VirtualizedList';
 import { useState } from 'react';
 
 /**
@@ -11,7 +11,7 @@ import { useState } from 'react';
  * doesn't support dynamic size changes.
  */
 export const VirtualizedListWithSize = typedMemo(
-  <T extends ItemWithIndex>(props: Omit<VirtualizedListProps<T>, 'listSizeInPx'>) => {
+  <T,>(props: Omit<VirtualizedListProps<T>, 'listSizeInPx'>) => {
     const isVertical = props.orientation === 'vertical';
     const [listSizeInPx, setListSizeInPx] = useState<number>(
       isVertical ? Dimensions.get('window').height : Dimensions.get('window').width,

--- a/packages/lib/src/spatial-navigation/components/virtualizedList/helpers/addIndex.ts
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/helpers/addIndex.ts
@@ -1,5 +1,0 @@
-import { ItemWithIndex } from '../VirtualizedList';
-
-export const addIndex = <T>(array: Array<T>): Array<T & ItemWithIndex> => {
-  return array.map((value, index) => ({ index, ...value }));
-};


### PR DESCRIPTION
An index was manually added to every iterable data passed to `VirtualizedLists`.
In `convertToGrid` function (dedicated to `VirtualizedGrids`), we saw that map gives access to the `index` of every item of data.

We can use the same for `VirtualizedLists` by using the index passed inside the `renderItem` prop.

The refactoring is cut in 2 parts : 
- Pass index to all components that use one (from bottom layers to top layers)
- Delete ItemWithIndex.

Tests realized on Web : 


https://github.com/bamlab/react-tv-space-navigation/assets/74320569/322a3917-6761-45b9-8402-8b46d0684a01

## Some performance tests 

| Scenario | Before | After |
| ---- | ------ | ------ |
| Display Home | <img width="1512" alt="avant affichage home" src="https://github.com/bamlab/react-tv-space-navigation/assets/74320569/136ce850-0524-4c73-8e6f-5dad2d6e03b0"> | <img width="1512" alt="affichage home" src="https://github.com/bamlab/react-tv-space-navigation/assets/74320569/f5dd4a55-4970-4490-ae97-f97c4cd302cc"> |
| Scroll horizontally home | <img width="1512" alt="avant horizontal home " src="https://github.com/bamlab/react-tv-space-navigation/assets/74320569/84d62408-5eb2-48ac-a0bd-34e986e981be"> | <img width="1512" alt="scroll horizontal home" src="https://github.com/bamlab/react-tv-space-navigation/assets/74320569/202f2648-7e15-47e3-b1ca-8d061fae27a3"> |
| Scroll vertically home | <img width="1512" alt="avant vertical home " src="https://github.com/bamlab/react-tv-space-navigation/assets/74320569/1fec6593-fd3a-4c5a-ba90-98053eb38a48"> | <img width="1512" alt="scroll vertical home" src="https://github.com/bamlab/react-tv-space-navigation/assets/74320569/c3478036-2736-471c-84ca-15c6699a296f"> |
| Display Grid | <img width="1512" alt="avant affichage grid " src="https://github.com/bamlab/react-tv-space-navigation/assets/74320569/eb6f97f0-06cc-4077-b198-c3b184284f66"> | <img width="1512" alt="affichage grid" src="https://github.com/bamlab/react-tv-space-navigation/assets/74320569/94f0a2b9-7b3e-4e0f-b76c-b1535e250df1"> |
| Scroll Horizontal Grid | <img width="1512" alt="avant horizontal grid" src="https://github.com/bamlab/react-tv-space-navigation/assets/74320569/4c86516a-3fd9-483c-9d1a-186a9d8fd164"> | <img width="1512" alt="scroll horizontal grid" src="https://github.com/bamlab/react-tv-space-navigation/assets/74320569/facefe46-adb4-4565-8b13-9a8fa435c31b"> |
| Scroll Vertical Grid | <img width="1512" alt="avant vertical grid" src="https://github.com/bamlab/react-tv-space-navigation/assets/74320569/fc00bebc-ec50-460f-9e3c-964658f1eb10"> | <img width="1512" alt="scroll vertical grid" src="https://github.com/bamlab/react-tv-space-navigation/assets/74320569/ce927c54-ebbd-4bde-8393-06d9e321ea82"> |











