### PR TITLE
chore: fix wrong monorepo config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-tv-space-navigation-monorepo",
   "workspaces": [
-    "packages/**"
+    "packages/*"
   ],
   "private": true,
   "packageManager": "yarn@3.5.1",


### PR DESCRIPTION
It was causing issues with npm when Pods in packages/example/ios directory were present