### PR TITLE
fix: list with variable size scroll and style

### DIFF
--- a/packages/example/src/modules/program/view/ProgramList.tsx
+++ b/packages/example/src/modules/program/view/ProgramList.tsx
@@ -161,6 +161,7 @@ const Container = styled.View<{ isActive: boolean }>(({ isActive, theme }) => ({
   padding: theme.spacings.$8,
   borderRadius: scaledPixels(20),
   overflow: 'hidden',
+  width: '100%',
 }));
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
The container width in the list was not set correctly, causing it to have a variable size. This pull request fixes the issue by setting the width of the container to 100%.