### PR TITLE
feat(VirtualizedList): provide a way to scroll without applying focus

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -258,9 +258,10 @@ It also ensures that the scroll event is propagated properly to parent ScrollVie
 
 The `SpatialNavigationVirtualizedList` component ref expose the following methods:
 
-| Name    | Type                      | Description                                               |
-| ------- | ------------------------- | --------------------------------------------------------- |
-| `focus` | `(index: number) => void` | Give the focus to the selected node and scroll if needed. |
+| Name       | Type                      | Description                                                    |
+| ---------- | ------------------------- | -------------------------------------------------------------- |
+| `focus`    | `(index: number) => void` | Give the focus to the selected node and scroll if needed.      |
+| `scrollTo` | `(index: number) => void` | Scroll to the selected node if needed, without appyling focus. |
 
 ## Usage
 

--- a/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedList.test.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedList.test.tsx
@@ -658,4 +658,21 @@ describe('SpatialNavigationVirtualizedList', () => {
     });
     expectButtonToHaveFocus(component, 'button 1');
   });
+
+  it('scroll to index in the list, without applying focus', async () => {
+    const component = renderVirtualizedListWithNavigationButtons(10);
+    act(() => jest.runAllTimers());
+
+    setComponentLayoutSize(listTestId, component, { width: 300, height: 300 });
+    const listElement = await component.findByTestId(listTestId);
+
+    expectButtonToHaveFocus(component, 'button 1');
+    expectListToHaveScroll(listElement, 0);
+
+    act(() => {
+      currentListRef?.current?.scrollTo(8);
+    });
+    expectButtonToHaveFocus(component, 'button 1');
+    expectListToHaveScroll(listElement, 0);
+  });
 });

--- a/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedListWithScroll.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedListWithScroll.tsx
@@ -197,19 +197,24 @@ export const SpatialNavigationVirtualizedListWithScroll = typedMemo(
         [deviceTypeRef],
       );
 
+      const scrollTo = useCallback((index: number) => {
+        if (idRef.current) {
+          const newId = idRef.current.getNthVirtualNodeID(index);
+          spatialNavigator.grabFocusDeferred(newId);
+        }
+      }, [idRef, spatialNavigator]);
+
       useImperativeHandle(
         ref,
         () => ({
-          focus: async (index: number) => {
+          focus: (index: number) => {
             setCurrentlyFocusedItemIndex(index);
-            if (idRef.current) {
-              const newId = idRef.current.getNthVirtualNodeID(index);
-              spatialNavigator.grabFocusDeferred(newId);
-            }
+            scrollTo(index);
           },
+          scrollTo,
           currentlyFocusedItemIndex,
         }),
-        [currentlyFocusedItemIndex, idRef, spatialNavigator],
+        [currentlyFocusedItemIndex, scrollTo],
       );
 
       const renderWrappedItem: typeof props.renderItem = useCallback(

--- a/packages/lib/src/spatial-navigation/types/SpatialNavigationVirtualizedListRef.ts
+++ b/packages/lib/src/spatial-navigation/types/SpatialNavigationVirtualizedListRef.ts
@@ -1,4 +1,5 @@
 export type SpatialNavigationVirtualizedListRef = {
   focus: (index: number) => void;
+  scrollTo: (index: number) => void;
   currentlyFocusedItemIndex: number;
 };


### PR DESCRIPTION
Currently there's only a way to programmatically change the focused item in the list. This PR adds the support for an additional `scrollTo` method. Which functions the same as `focus`, but instead just scrolls and doesn't actually focus.