### PR TITLE
fix: onEndReached does not fire in SpatialNavigationVirtualizedList.

### DIFF
--- a/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedListWithScroll.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/SpatialNavigationVirtualizedListWithScroll.tsx
@@ -197,12 +197,15 @@ export const SpatialNavigationVirtualizedListWithScroll = typedMemo(
         [deviceTypeRef],
       );
 
-      const scrollTo = useCallback((index: number) => {
-        if (idRef.current) {
-          const newId = idRef.current.getNthVirtualNodeID(index);
-          spatialNavigator.grabFocusDeferred(newId);
-        }
-      }, [idRef, spatialNavigator]);
+      const scrollTo = useCallback(
+        (index: number) => {
+          if (idRef.current) {
+            const newId = idRef.current.getNthVirtualNodeID(index);
+            spatialNavigator.grabFocusDeferred(newId);
+          }
+        },
+        [idRef, spatialNavigator],
+      );
 
       useImperativeHandle(
         ref,

--- a/packages/lib/src/spatial-navigation/components/virtualizedList/VirtualizedList.tsx
+++ b/packages/lib/src/spatial-navigation/components/virtualizedList/VirtualizedList.tsx
@@ -70,8 +70,7 @@ const useOnEndReached = ({
     }
 
     if (
-      currentlyFocusedItemIndex ===
-      Math.max(numberOfItems - 1 - onEndReachedThresholdItemsNumber, 0)
+      currentlyFocusedItemIndex >= Math.max(numberOfItems - 1 - onEndReachedThresholdItemsNumber, 0)
     ) {
       onEndReached?.();
     }


### PR DESCRIPTION
## Implement

- Fixed determination of focus position for onEndReached when it exceeds rather than equals
- Fixed lint


## Issue

https://github.com/bamlab/react-tv-space-navigation/issues/189