### PR TITLE
chore: add description to package.json

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -2,10 +2,8 @@
   "name": "react-tv-space-navigation",
   "version": "5.2.0",
   "main": "dist/index.js",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/bamlab/react-tv-space-navigation.git"
-  },
+  "description": "A React Native module to handle spatial navigation for a TV application in a 100% cross-platform way",
+  "repository": "github:bamlab/react-tv-space-navigation",
   "license": "MIT",
   "devDependencies": {
     "@testing-library/react-hooks": "^8.0.1",


### PR DESCRIPTION
# Why

I have spotted that the package does not have a description in the React Native Directory.

<img width="2412" height="458" alt="Screenshot 2025-08-13 at 09 01 17" src="https://github.com/user-attachments/assets/d7acd434-ff9b-49fa-9ce0-28542738f0c9" />

# How

Fill out [package.json `description` field](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#description-1) with the content from GitHub repository description. Update [`repository` field](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#repository) to use short format for GitHub hosted projects.